### PR TITLE
Created prepare-commit-msg git hook

### DIFF
--- a/src/Commands/CommitHooks/PrepareCommitMsg.php
+++ b/src/Commands/CommitHooks/PrepareCommitMsg.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Feek\LaravelGitHooks\Commands\CommitHooks;
+
+class PrepareCommitMsg extends CommitHookCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hooks:prepare-commit-msg';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Invoked within git prepare-commit-msg hook';
+
+    /**
+     * @return string
+     */
+    function getConfigKey()
+    {
+        return 'hooks.prepare-commit-msg';
+    }
+}

--- a/src/Commands/InstallHooks.php
+++ b/src/Commands/InstallHooks.php
@@ -32,7 +32,7 @@ class InstallHooks extends BaseCommand
         $srcPath = __DIR__ . '/../Hooks/';
         $destPath = base_path() . '/.git/hooks/';
 
-        $files = ['pre-commit', 'pre-push'];
+        $files = ['pre-commit', 'pre-push', 'prepare-commit-msg'];
 
         foreach($files as $file) {
             $source = $srcPath . $file . '.sh';

--- a/src/Config/hooks.php
+++ b/src/Config/hooks.php
@@ -28,6 +28,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Commands to run prepare-commit-msg
+    |--------------------------------------------------------------------------
+    |
+    | Here is where you should list each artisan command that you want run
+    | prior to a git push. If any of these commands fail, then the
+    | push will fail. Add as many or few as you want.
+    */
+    'prepare-commit-msg' => [],
+
+    /*
+    |--------------------------------------------------------------------------
     | Commands to run pre-push
     |--------------------------------------------------------------------------
     |

--- a/src/Hooks/prepare-commit-msg.sh
+++ b/src/Hooks/prepare-commit-msg.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+php artisan hooks:prepare-commit-msg
+
+STATUS_CODE=$?
+if [ ! ${STATUS_CODE} -eq 0 ]; then
+    echo "COMMIT MESSAGE REJECTED: ${STATUS_CODE}"
+    exit ${STATUS_CODE}
+fi
+
+exit 0;

--- a/src/LaravelGitHooksServiceProvider.php
+++ b/src/LaravelGitHooksServiceProvider.php
@@ -8,6 +8,7 @@ use Feek\LaravelGitHooks\Commands\Phpcbf;
 use Feek\LaravelGitHooks\Commands\InstallHooks;
 use Feek\LaravelGitHooks\Commands\CommitHooks\PreCommit;
 use Feek\LaravelGitHooks\Commands\CommitHooks\PrePush;
+use Feek\LaravelGitHooks\Commands\CommitHooks\PrepareCommitMsg;
 use Feek\LaravelGitHooks\Commands\PhpUnit;
 use Illuminate\Support\ServiceProvider;
 
@@ -28,7 +29,8 @@ class LaravelGitHooksServiceProvider extends ServiceProvider
                 InstallHooks::class,
                 PhpUnit::class,
                 PreCommit::class,
-                PrePush::class
+                PrePush::class,
+                PrepareCommitMsg::class
             ]);
 
             $this->publishes([


### PR DESCRIPTION
## Description

Implemented "prepare-commit-msg" as described in #5 

[!] I didn't added artisan commands to default config. 
Do you have an idea for useful events at this hook? Maybe adding some info (like branch name) to commit message?

## Checklist:

- [x]  create bash file in src/hooks named prepare-commit-msg.sh, and can use the others as a template.
- [x]  edit config/hooks.php and add a new array key config for the pre-commit-msg hook.
- [x]  create a new command in src/Commands/CommitHooks named PrepareCommitMessage, which extends CommitHookCommand. The getConfigKey function should be implemented to point to the configuration key created in the previous step.
- [x] ensure that this new command is made available
- [x] add the new prepare-commit-msg.sh file to the list of files to be copied over.
