### PR TITLE
#10 create artisan command to composer install

### DIFF
--- a/src/Commands/ComposerInstall.php
+++ b/src/Commands/ComposerInstall.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Feek\LaravelGitHooks\Commands;
+
+class ComposerInstall extends BaseCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hooks:composer-install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run composer install';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $composerCommand = exec('which composer');
+
+        if (! $composerCommand) {
+            $this->warn('composer not installed');
+            return;
+        }
+        exec($composerCommand . ' install');
+    }
+}

--- a/src/LaravelGitHooksServiceProvider.php
+++ b/src/LaravelGitHooksServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Feek\LaravelGitHooks;
 
+use Feek\LaravelGitHooks\Commands\ComposerInstall;
 use Feek\LaravelGitHooks\Commands\ESLint;
 use Feek\LaravelGitHooks\Commands\Phpcs;
 use Feek\LaravelGitHooks\Commands\Phpcbf;
@@ -22,6 +23,7 @@ class LaravelGitHooksServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
+                ComposerInstall::class,
                 ESLint::class,
                 Phpcs::class,
                 Phpcbf::class,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Create artisan command to composer install

## Motivation and context

This pull request based on #10 

## How has this been tested?

artisan command can be found at `src/Commands/ComposerInstall` and can be used by `hooks-composer-install`
if composer not installed, it will show warning message said that composer is not installed.